### PR TITLE
Missing Omit Marker on first Find Request

### DIFF
--- a/src/Command/CompoundFind.php
+++ b/src/Command/CompoundFind.php
@@ -96,7 +96,7 @@ class CompoundFind extends Command
             $critCount = count($findCriterias);
 			
 			//If the first find request is marked as omit
-			if($this->_requests[$precedence]->omit === true){
+			if($this->_requests[$precedence]->omit === true && $precedence == '1'){
 				$query .= "!";
 			}
 

--- a/src/Command/CompoundFind.php
+++ b/src/Command/CompoundFind.php
@@ -94,6 +94,11 @@ class CompoundFind extends Command
         foreach ($this->_requests as $precedence => $request) {
             $findCriterias = $request->findCriteria;
             $critCount = count($findCriterias);
+			
+			//If the first find request is marked as omit
+			if($this->_requests[$precedence]->omit === true){
+				$query .= "!";
+			}
 
             $query .= '(';
 


### PR DESCRIPTION
When using compoundFind and having findRequests only the 2nd findRequest and on where checking for the omit flag.
This fixes so that the first FindRequest also implements the omit flag

