### PR TITLE
Handle preg_match returning array with 4 elements

### DIFF
--- a/src/Object/Field.php
+++ b/src/Object/Field.php
@@ -187,17 +187,17 @@ class Field
                                     $value,
                                     $matches
                                 );
-                                if (count($matches) !== 3) {
+                                if (count($matches) !== 4) {
                                     $validationError->addError($this, $rule, $value);
                                 } else {
-                                    $strlen = strlen($matches[2]);
+                                    $strlen = strlen($matches[3]);
                                     if ($strlen !== 4) {
                                         $validationError->addError($this, $rule, $value);
                                     } else {
-                                        if ($matches[2] < 1 || $matches[2] > 4000) {
+                                        if ($matches[3] < 1 || $matches[3] > 4000) {
                                             $validationError->addError($this, $rule, $value);
                                         } else {
-                                            if (!checkdate($matches[0], $matches[1], $matches[2])) {
+                                            if (!checkdate($matches[1], $matches[2], $matches[3])) {
                                                 $validationError->addError($this, $rule, $value);
                                             }
                                         }


### PR DESCRIPTION
The code is written as if `preg_match` returns only the three individual date parts. It actually returns an extra first element that contains the whole date, which breaks the rest of the validation. This should fix that.