### PR TITLE
Add missing isError checks on internal query results

### DIFF
--- a/src/Command/Add.php
+++ b/src/Command/Add.php
@@ -69,6 +69,9 @@ class Add extends Command
             } else {
                 $fieldname = $field;
                 $fieldInfos = $layout->getField($field);
+                if (FileMaker::isError($fieldInfos)) {
+                    return $fieldInfos;
+                }
                 if ($fieldInfos->isGlobal()) {
                     $fieldType = '.global';
                 } else {

--- a/src/Object/Layout.php
+++ b/src/Object/Layout.php
@@ -89,7 +89,11 @@ class Layout
         if ($pos = strpos($fieldName, ':')) {
             $relatedSet = substr($fieldName, 0, $pos);
             //$fieldName = substr($fieldName, $pos+1, strlen($fieldName));
-            return $this->getRelatedSet($relatedSet)->getField($fieldName);
+            $result = $this->getRelatedSet($relatedSet);
+            if (FileMaker::isError($result)) {
+                return $result;
+            }
+            return $result->getField($fieldName);
         }
         return $this->fm->returnOrThrowException('Field "'.$fieldName.'" Not Found');
     }


### PR DESCRIPTION
When a field info query or layout query comes back as a FileMaker error, return the error instead of crashing.