### PR TITLE
Fix test for related set

### DIFF
--- a/src/Object/Record.php
+++ b/src/Object/Record.php
@@ -381,7 +381,7 @@ class Record
      */
     public function getRelatedSet($relatedSet)
     {
-        if (!isset($this->relatedSets[$relatedSet])) {
+        if (!isset($this->relatedSets[$relatedSet]) || empty($this->relatedSets[$relatedSet])) {
             return $this->fm->returnOrThrowException('Related set "' . $relatedSet . '" not present.');
         }
         return $this->relatedSets[$relatedSet];


### PR DESCRIPTION
Fix test for related set so that it properly returns or throws an error when there are no related records.