### PR TITLE
Typofix

### DIFF
--- a/src/Command/Edit.php
+++ b/src/Command/Edit.php
@@ -141,7 +141,7 @@ class Edit extends Command
         if (FileMaker::isError($layout)) {
             return $layout;
         }
-        $fieldInfos = $layout->getField($field);
+        $fieldInfos = $layout->getField($fieldname);
         if(FileMaker::isError($fieldInfos)){
             return $fieldInfos;
         }


### PR DESCRIPTION
When trying to add a child record via a relationship it fails:
$fm_record = $fm_result->getFirstRecord();
$fm_child = $fm_record->newRelatedRecord('XYZRelations');
$fm_child->setField('XYZRelations::SomeField', 'something');
$fm_child->commit();

This change fixes this error: "Field XYZRelations::SomeField.0 Not Found in Layout"
BUT a new error appears and I have no idea what is causing it: 102 - "Field is missing"
If someone could look into that I'd really appreciate it.