### PR TITLE
Fix memory leak

### DIFF
--- a/src/Parser/FMResultSet.php
+++ b/src/Parser/FMResultSet.php
@@ -82,6 +82,7 @@ class FMResultSet
             );
         }
         xml_parser_free($this->xmlParser);
+        unset($this->xmlParser);
         if (!empty($this->errorCode)) {
             return $this->fm->returnOrThrowException(null, $this->errorCode);
         }


### PR DESCRIPTION
Hi 👋 
When using your excellent library to get some big content out of a filemaker database we saw a memory leak happening 

Here is a screenshot of xhprof which shows how much executing a FM result once causes in terms of memory:

![image](https://user-images.githubusercontent.com/29678/70246382-92355980-176f-11ea-8ec6-94830a12a1a6.jpeg)

Long story short, I found this commit: http://svn.php.net/viewvc/phpdoc/en/trunk/reference/xml/functions/xml-set-object.xml?r1=339867&r2=339866&pathrev=339867

Once applied the leak no longer appears 🎆 
