### PR TITLE
Made compound find precedence optional

### DIFF
--- a/src/Command/CompoundFind.php
+++ b/src/Command/CompoundFind.php
@@ -32,14 +32,18 @@ class CompoundFind extends Command
      /**
      * Adds a Find Request object to this Compound Find command.
      *
-     * @param int $precedence Priority in which the find requests are added to
-     *        this compound find set.
      * @param FindRequest $findrequest {@link FindRequest} object
      *        to add to this compound find set.
+     * @param int|bool $precedence Priority in which the find requests are added to
+     *        this compound find set.
      */
-    public function add($precedence, FindRequest $findrequest)
+    public function add(FindRequest $findrequest, $precedence = false)
     {
-        $this->requests[$precedence] = $findrequest;
+        if ($precedence === false) {
+            $this->requests[] = $findrequest;
+        } else {
+            $this->requests[$precedence] = $findrequest;
+        }
     }
 
      /**


### PR DESCRIPTION
When creating a compound find, we found it inconvenient to have to keep track on the precedence parameter such to not overwrite the previous find requests. 

The precedence parameter can now be set to false to append the new find request to the end. We also switched the parameters around in order to make the precedence parameter optional.