### PR TITLE
Fix: Optimisation of addFindCriterion

### DIFF
--- a/src/Command/RequestTrait.php
+++ b/src/Command/RequestTrait.php
@@ -22,12 +22,11 @@ trait RequestTrait
      */
     public function addFindCriterion($fieldName, $value)
     {
-        $fieldType = $this->getFieldResult($fieldName);
-        if ($this->fm->useDateFormatInRequests
-            && $this->fm->dateFormat !== null
-            && ($fieldType == "date" || $fieldType == "datetime")
-        ) {
-            $value = DateFormat::convertSearchCriteria($value, $this->fm->dateFormat, 'm/d/Y');
+        if ($this->fm->useDateFormatInRequests && $this->fm->dateFormat !== null) {
+            $fieldType = $this->getFieldResult($fieldName);
+            if ($fieldType == "date" || $fieldType == "datetime") {
+                $value = DateFormat::convertSearchCriteria($value, $this->fm->dateFormat, 'm/d/Y');
+            }
         }
         $this->findCriteria[$fieldName] = $value;
         return $this;


### PR DESCRIPTION
We noticed that AddFindCriterion did an unnecessary API call for handling date formats even when useDateFormatInRequests is set to false. We did a small change to make sure getFieldResult is only called when actually needed.