### PR TITLE
Fix: Edit command doesn't return metadata

### DIFF
--- a/src/Command/Edit.php
+++ b/src/Command/Edit.php
@@ -143,8 +143,7 @@ class Edit extends Command
             if (FileMaker::isError($parseResult)) {
                 return $parseResult;
             }
-            $result = new Result($this->fm);
-            $result->records[] = $this->fm->getRecordById($this->layout, $this->recordId);
+            $result = $this->fm->getRecordById($this->layout, $this->recordId, true);
         }
         return $result;
     }

--- a/src/FileMaker.php
+++ b/src/FileMaker.php
@@ -532,16 +532,17 @@ class FileMaker
      *
      * @param string $layout Layout that $recordId is in.
      * @param string $recordId ID of the record to get.
+     * @param boolean $getResult Return result instead of record
      *
      * @return Object\Record|FileMakerException
      * @throws FileMakerException
      */
-    public function getRecordById($layout, $recordId)
+    public function getRecordById($layout, $recordId, $getResult = false)
     {
         $request = $this->newFindCommand($layout);
         $request->setRecordId($recordId);
         $result = $request->execute();
-        if (FileMaker::isError($result)) {
+        if ($getResult || FileMaker::isError($result)) {
             return $result;
         }
 


### PR DESCRIPTION
Fix for the edit command currently only returning the record data without any result metadata such as found count.