### PR TITLE
PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["filemaker","PHP-API"],
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^5.5|^7.0"
+        "php": "^5.5|^7.0|^8.0"
     },
     "authors": [
         {

--- a/src/FileMaker.php
+++ b/src/FileMaker.php
@@ -1140,7 +1140,7 @@ class FileMaker
      * @return null|FileMakerException $previous
      * @throws FileMakerException
      */
-    public function returnOrThrowException($message = null, $code = null, $previous = null)
+    public function returnOrThrowException($message = null, $code = 0, $previous = null)
     {
         $exception = new FileMakerException($this, $message, $code, $previous);
         if ($this->getProperty('errorHandling') == 'exception') {

--- a/src/FileMaker.php
+++ b/src/FileMaker.php
@@ -1140,7 +1140,7 @@ class FileMaker
      * @return null|FileMakerException $previous
      * @throws FileMakerException
      */
-    public function returnOrThrowException($message = null, $code = 0, $previous = null)
+    public function returnOrThrowException($message = null, $code = -1, $previous = null)
     {
         $exception = new FileMakerException($this, $message, $code, $previous);
         if ($this->getProperty('errorHandling') == 'exception') {

--- a/src/FileMakerException.php
+++ b/src/FileMakerException.php
@@ -32,10 +32,10 @@ class FileMakerException extends \Exception
      * @param integer $code Error code.
      * @param null|\Exception $previous
      */
-    public function __construct($fm, $message = null, $code = null, $previous = null)
+    public function __construct($fm, $message = null, $code = -1, $previous = null)
     {
         $this->fm = $fm;
-        if ($code !== null) {
+        if (empty($message)) {
             $message = $this->getErrorString($code);
         }
 


### PR DESCRIPTION
- Added PHP 8 to list of compatible versions in composer.json.
- No longer creates exceptions with a null code, which was deprecated in PHP 8.1. The exception constructor now defaults to `-1` instead of `null` and the message is only replaced with `getErrorString($code)` if it is empty, rather than if the code is not `null`. This seems to work as intended but let me know if anyone thinks this might have unexpected consequences.